### PR TITLE
stack prefix syntax: always have a "::" at the end, empty prefix is just "::"

### DIFF
--- a/examples.ml
+++ b/examples.ml
@@ -44,7 +44,7 @@ let factorial_t' =
 let factorial_t = Parse.parse_string Parser.f_expression_eof {|
 lam (x:int).
   FT[(int) -> int, ?]
-    ([protect , z2;
+    ([protect ::, z2;
       mv r1, lf0;
       halt
         box forall[z2, e3].
@@ -70,7 +70,7 @@ lam (x:int).
 let blocks_1 = Parse.parse_string Parser.f_expression_eof {|
 lam (x:int).
   FT[(int) -> int, ?]
-    ([protect , z2;
+    ([protect ::, z2;
       mv r1, l2;
       halt
         box forall[z3, e4].
@@ -86,7 +86,7 @@ lam (x:int).
 let blocks_2 = Parse.parse_string Parser.f_expression_eof {|
 lam (x:int).
   FT[(int) -> int, ?]
-    ([protect , z2;
+    ([protect ::, z2;
       mv r1, l2;
       halt
         box forall[z4, e5].
@@ -162,11 +162,11 @@ let ref_settyp = F.(TArrowMod ([TInt], [TAL.(TTupleRef [TInt])], [TAL.(TTupleRef
 let ref_gettyp = F.(TArrowMod ([], [TAL.(TTupleRef [TInt])], [TAL.(TTupleRef [TInt])], TInt))
 
 let with_ref = Parse.parse_string Parser.f_expression_eof {|
-lam (init:int, k:((int)[ref <int>] -> [ref <int>]unit,
-                   ()[ref <int>] -> [ref <int>]int) -> int).
+lam (init:int, k:((int)[ref <int> :: ] -> [ref <int>::]unit,
+                   ()[ref <int>::] -> [ref <int>::]int) -> int).
   (lam (_:unit, res:int, _:unit). res)
     FT[unit, ref <int> :: z]
-      ([protect , z;
+      ([protect ::, z;
         salloc 1;
         import r1, z_ as z, int TF{init};
         sst 0, r1;
@@ -177,7 +177,7 @@ lam (init:int, k:((int)[ref <int>] -> [ref <int>]unit,
         halt unit, ref <int> :: z {r1}],
         [])
     (k
-      (lam [ref <int>][ref <int>](x:int).
+      (lam [ref <int>::][ref <int>::](x:int).
         FT[unit,
            ref <int>
              :: box forall[z12, e13].
@@ -215,7 +215,7 @@ lam (init:int, k:((int)[ref <int>] -> [ref <int>]unit,
                          {ra : box forall[].{r1 : int; ref <int> :: z16} e17;
                           ref <int> :: z16} ra :: z12} ra :: z1 {r1}],
               []))
-      (lam [ref <int>][ref <int>]().
+      (lam [ref <int>::][ref <int>::]().
         FT[int,
            ref <int>
              :: box forall[z12, e13].
@@ -241,7 +241,7 @@ lam (init:int, k:((int)[ref <int>] -> [ref <int>]unit,
                           ref <int> :: z16} ra :: z12} ra :: z1 {r2}],
               [])))
     FT[unit, z]
-      ([protect ref <int>, z; sfree 1; mv r1, (); halt unit, z {r1}],
+      ([protect ref <int>::, z; sfree 1; mv r1, (); halt unit, z {r1}],
         [])
 |}
 

--- a/ftal.ml
+++ b/ftal.ml
@@ -1927,14 +1927,18 @@ end = struct
     group @@ match s with
     | SConcrete l ->
       if List.length l > 0 then
-        p_sigma_prefix l ^^ !^" :: *"
+        p_sigma_prefix l ^^ !^" *"
       else !^"*"
     | SAbstract (l, z) ->
       if List.length l > 0 then
-        p_sigma_prefix l ^^ !^" :: " ^^ !^z
+        p_sigma_prefix l ^^ !^" " ^^ !^z
       else !^z
   and p_sigma_prefix (p : sigma_prefix) : document =
-    group @@ nest 2 @@ separate_map (break 1 ^^ !^":: ") p_t p
+    let rec loop = function
+      | [] -> !^"::"
+      | [t] -> p_t t ^^ !^"::"
+      | t::ts -> p_t t ^^ break 1 ^^ !^":: " ^^ loop ts in
+    group @@ nest 2 @@ loop p
   and p_q (q : q) : document =
     group @@ match q with
     | QR r -> !^r

--- a/parser.mly
+++ b/parser.mly
@@ -209,7 +209,12 @@ register_typing: li=bracketed(simple_register_typing) { li }
 simple_register_typing: li=separated_list(COMMA, decl(register, value_type)) { li }
 
 stack_prefix:
-  | taus=separated_list(DOUBLECOLON, value_type) { taus }
+  | DOUBLECOLON { [] }
+  | tau=value_type taus=rest_stack_prefix { tau :: taus }
+
+  rest_stack_prefix:
+  | DOUBLECOLON { [] }
+  | DOUBLECOLON tau=value_type taus=rest_stack_prefix { tau :: taus }
 
 stack_typing:
 | prefix=list(tau=value_type DOUBLECOLON {tau}) finish=stack_typing_end

--- a/test.ml
+++ b/test.ml
@@ -160,7 +160,7 @@ let test_import_stk_ty _ =
        (FTAL.TC (tal_comp "([salloc 3;
                              import r1, z' as unit::*, int TF{
                                FT [int, unit::z'] (
-                                 [protect unit, z;
+                                 [protect unit::, z;
                                   mv r1, 10;
                                   sfree 1;
                                   halt int, z {r1}]

--- a/web.ml
+++ b/web.ml
@@ -32,7 +32,7 @@ FT [int, ?] (
 let omega = {|
   (lam(f : mu a. (a) -> a).((unfold f) f))
   (fold (mu a. (a) -> a) lam(f : mu a. (a) -> a).((unfold f) f))
-  |}
+|}
 
 let higher_order = Ftal.F.show_exp Examples.higher_order
 let factorial_f = Ftal.(F.show_exp (F.EApp (dummy_loc, Examples.factorial_f, [F.EInt (dummy_loc, 3)])))
@@ -41,7 +41,8 @@ let call_to_call = Ftal.(F.show_exp (F.(EBoundary (dummy_loc, TInt, None, Exampl
 let blocks_1 = Ftal.(F.show_exp (F.EApp (dummy_loc, Examples.blocks_1, [F.EInt (dummy_loc, 3)])))
 let blocks_2 = Ftal.(F.show_exp (F.EApp (dummy_loc, Examples.blocks_2, [F.EInt (dummy_loc, 3)])))
 
-let parse_error = {| FT [int, ?] (
+let parse_error = {|
+FT [int, ?] (
   [mv r1, 1;
    add r1, r1, 1
    halt int, * {r1}],
@@ -59,7 +60,8 @@ let type_error = {|
         if0 x1
           1
           (x1*((unfold f) f (x1-1)))))
-    x2) 3 |}
+    x2) 3
+|}
 
 let set_error ln m =
   let _ = Js.Unsafe.((coerce global)##seterror (Js.number_of_float (float_of_int ln)) (Js.string m)) in


### PR DESCRIPTION
There are two choices:

1. always impose a trailing `::` for stack prefixes, for example `int ::`, `unit :: int ::` and `::`
2. only impose a trailing `::` for the *empty* prefix, so that `int ::`, `int`, `::` are all accepted (but not the empty string).

The current patch implements (1). Let me know if you would prefer (2) instead.