### PR TITLE
Make the world a Better Place

### DIFF
--- a/artifact/index.html
+++ b/artifact/index.html
@@ -165,7 +165,7 @@
 
         <tr>
           <td><code>import r,<sup>&sigma;</sup>TF<sup>&tau;</sup> e</code></td>
-          <td><code>import r1, z as s, t TF{e};</code></td>
+          <td><code>import r1, s as z, t TF{e};</code></td>
           <td><code>import</code> binds the stack <code>s</code> on
           return as <code>z</code> with Fun expression <code>e</code> of
           type <code>t</code>.</td>

--- a/ftal.ml
+++ b/ftal.ml
@@ -2010,7 +2010,7 @@ end = struct
     | Iimport(_,r,z,s,t,e) ->
       !^"import " ^^ args [
         !^r;
-        !^z ^^ space ^^ !^"as" ^^ space ^^ p_s s;
+        p_s s ^^ space ^^ !^"as" ^^ space ^^ !^z;
         FP.p_t t ^^ space ^^ !^ "TF" ^^ (braces @@ align @@ FP.p_exp e);
       ]
   and p_instruction_sequence (is : instr list) : document =

--- a/parser.messages
+++ b/parser.messages
@@ -1436,69 +1436,69 @@ component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA UNPACK
 ##
 ## Ends in an error in state: 192.
 ##
-## single_instruction -> IMPORT register COMMA . stack_typing_variable AS stack_typing COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA . stack_typing AS stack_typing_variable COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORT register COMMA 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
-we parsed "import <register>," so far and expect a stack variable.
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
+we parsed "import <register>," so far and expect a stack typing.
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS UNPACK 
 ##
 ## Ends in an error in state: 194.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable AS . stack_typing COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing AS . stack_typing_variable COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable AS 
+## IMPORT register COMMA stack_typing AS 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
-we parsed "import <register>, <stack variable> as" so far and expect
-a stack typing.
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
+we parsed "import <register>, <stack typing> as" so far and expect
+a stack variable.
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS Z_IDENTIFIER COMMA UNPACK 
 ##
 ## Ends in an error in state: 196.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable AS stack_typing COMMA . f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing AS stack_typing_variable COMMA . f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable AS stack_typing COMMA 
+## IMPORT register COMMA stack_typing AS stack_typing_variable COMMA 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
-we parsed "import <register>, <stack variable> as <stack typing>," so far and expect
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
+we parsed "import <register>, <stack typing> as <stack variable>," so far and expect
 a type.
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS Z_IDENTIFIER COMMA Z_IDENTIFIER TF LBRACE UNPACK 
 ##
 ## Ends in an error in state: 229.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type TF LBRACE . f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type TF LBRACE . f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type TF LBRACE 
+## IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type TF LBRACE 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
-we parsed "import <register>, <stack variable> as <stack typing>,
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
+we parsed "import <register>, <stack typing> as <stack variable>,
 <type> TF{" so far and expect a F expression.
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS Z_IDENTIFIER COMMA Z_IDENTIFIER TF LBRACE Z_IDENTIFIER RPAREN 
 ##
 ## Ends in an error in state: 309.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type TF LBRACE f_expression . RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type TF LBRACE f_expression . RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type TF LBRACE f_expression 
+## IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type TF LBRACE f_expression 
 ##
 ## WARNING: This example involves spurious reductions.
 ## This implies that, although the LR(1) items shown above provide an
@@ -1510,102 +1510,101 @@ component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS Z_IDENTIFIE
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
 we parsed
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr>"
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr>"
 so far and expect a closing bracket "}".
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS Z_IDENTIFIER COMMA Z_IDENTIFIER TF Z_IDENTIFIER 
 ##
 ## Ends in an error in state: 228.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type TF . LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type TF . LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type TF 
+## IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type TF 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
 we parsed
-"import <register>, <stack variable> as <stack typing>, <type> TF" so
+"import <register>, <stack typing> as <stack variable>, <type> TF" so
 far and expect a bracketed F expression "{ <expr> }".
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS Z_IDENTIFIER COMMA Z_IDENTIFIER Z_IDENTIFIER 
 ##
 ## Ends in an error in state: 227.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type . TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type . TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable AS stack_typing COMMA f_type 
+## IMPORT register COMMA stack_typing AS stack_typing_variable COMMA f_type 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
 we parsed
-"import <register>, <stack variable> as <stack typing>, <type>" so far
+"import <register>, <stack typing> as <stack variable>, <type>" so far
 and expect F expression within a boundary "TF{ <expr> }".
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER AS Z_IDENTIFIER Z_IDENTIFIER 
 ##
 ## Ends in an error in state: 195.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable AS stack_typing . COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing AS stack_typing_variable . COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable AS stack_typing 
+## IMPORT register COMMA stack_typing AS stack_typing_variable 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
 we parsed
-"import <register>, <stack variable> as <stack typing>" so far
+"import <register>, <stack typing> as <stack variable>" so far
 and expect a comma "," followed by a type.
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER COMMA Z_IDENTIFIER Z_IDENTIFIER 
 ##
 ## Ends in an error in state: 193.
 ##
-## single_instruction -> IMPORT register COMMA stack_typing_variable . AS stack_typing COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register COMMA stack_typing . AS stack_typing_variable COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
-## IMPORT register COMMA stack_typing_variable 
+## IMPORT register COMMA stack_typing 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
-we parsed "import <register>, <stack variable>" and expect the "as"
-keyword followed by a stack typing.
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
+we parsed "import <register>, <stack typing>" and expect the "as"
+keyword followed by a stack variable.
 
 component_eof: LPAREN LBRACKET IMPORT REGISTER Z_IDENTIFIER 
 ##
 ## Ends in an error in state: 191.
 ##
-## single_instruction -> IMPORT register . COMMA stack_typing_variable AS stack_typing COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT register . COMMA stack_typing AS stack_typing_variable COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORT register 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
 we parsed "import <register>" and expect the binding of a stack typing
-to a start variable, "<stack variable> as <stack typing>" -- don't ask
-me about the order.
+to a start variable, "<stack typing> as <stack variable>".
 
 component_eof: LPAREN LBRACKET IMPORT Z_IDENTIFIER 
 ##
 ## Ends in an error in state: 190.
 ##
-## single_instruction -> IMPORT . register COMMA stack_typing_variable AS stack_typing COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
+## single_instruction -> IMPORT . register COMMA stack_typing AS stack_typing_variable COMMA f_type TF LBRACE f_expression RBRACE [ SEMICOLON ]
 ##
 ## The known suffix of the stack is as follows:
 ## IMPORT 
 ##
 
 Parsing an import instruction
-"import <register>, <stack variable> as <stack typing>, <type> TF{ <expr> }",
+"import <register>, <stack typing> as <stack variable>, <type> TF{ <expr> }",
 we parsed the "import" keyword so far and expect the register in which
 to store the imported value.
 

--- a/parser.mly
+++ b/parser.mly
@@ -312,8 +312,9 @@ single_instruction:
   { Iunpack (cpos $startpos, alpha, rd, u) }
 | UNFOLD rd=register COMMA u=small_value
   { Iunfold (cpos $startpos, rd, u) }
-| IMPORT r=register COMMA zeta=stack_typing_variable
-  AS sigma=stack_typing COMMA tau=f_type TF LBRACE e=f_expression RBRACE
+| IMPORT r=register
+  COMMA sigma=stack_typing AS zeta=stack_typing_variable
+  COMMA tau=f_type TF LBRACE e=f_expression RBRACE
   { Iimport (cpos $startpos, r, zeta, sigma, tau, e) }
 | PROTECT phi=stack_prefix COMMA zeta=stack_typing_variable
   { Iprotect (cpos $startpos,phi, zeta) }

--- a/test.ml
+++ b/test.ml
@@ -116,7 +116,7 @@ let test_import_ty _ =
     (FTAL.tc
        (FTAL.default_context (TAL.(QEnd (TInt, SConcrete []))))
        (FTAL.TC
-          (tal_comp "([import r1, z as *, int TF{10}; halt int, * {r1}], [])")))
+          (tal_comp "([import r1, * as z, int TF{10}; halt int, * {r1}], [])")))
     (FTAL.TT TAL.TInt, TAL.SConcrete [])
 
 
@@ -125,7 +125,7 @@ let test_import_ty_exc _ =
     (fun _ -> FTAL.tc
        (FTAL.default_context (TAL.(QEnd (TInt, SConcrete []))))
        (FTAL.TC
-          (tal_comp "([import r1, z as *, int TF{()}; halt int, * {r1}], [])")))
+          (tal_comp "([import r1, * as z, int TF{()}; halt int, * {r1}], [])")))
 
 let test_import_ty_exc2 _ =
   assert_raises_typeerror
@@ -151,7 +151,7 @@ let test_import_stk_ty _ =
     (FTAL.tc
        (FTAL.default_context (TAL.(QEnd (TInt, SConcrete [TUnit]))))
        (FTAL.TC (tal_comp "([salloc 3;
-                             import r1, z' as unit::*, int TF{
+                             import r1, unit::* as z', int TF{
                                FT [int, unit::z'] (
                                  [protect unit::, z;
                                   mv r1, 10;

--- a/web.ml
+++ b/web.ml
@@ -58,7 +58,7 @@ let omega = {|
 |}
 
 let import = {|
-FT [int, ?] ([import r1, z as *, int TF{10}; halt int, * {r1}], [])
+FT [int, ?] ([import r1, * as z, int TF{10}; halt int, * {r1}], [])
 |}
 
 let higher_order = Ftal.F.show_exp Examples.higher_order


### PR DESCRIPTION
... by fixing the import syntax: `import r, z as unit::*, foo` is BAD, `import r, unit::* as z, foo` is GOOD.

(This is the only change I was secretly plotting.)